### PR TITLE
Mark explicit plugin/preset names with an `!`

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,9 @@ class BabelCompiler {
     // this is needed so that babel can locate presets when compiling node_modules
     const mapOption = type => data => {
       const resolvePath = name => (
-        resolve(config.paths.root, 'node_modules', `babel-${type}-${name}`)
+        if (/!$/.test(name)) name = name.replace(/!$/, '');
+        else name = `babel-${type}-${name}`;
+        resolve(config.paths.root, 'node_modules', name);
       );
       if (typeof data === 'string') return resolvePath(data);
       return [resolvePath(data[0]), data[1]];


### PR DESCRIPTION
This will not resolve the directly the issue, when a babel plugin/preset doesn't follow the babel-{type}-{name} convention.
But it will allow a consumer to specify this edgecases with an explicit mark at the end of the `plugin/preset-name!`.

And fixes #42